### PR TITLE
TLD change from .mini to .example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LC_ALL en_US.UTF-8
 
 ENV HOME /root
 ENV INSTALLER_BRANCH v205
-ENV NISE_DOMAIN cf.mini
+ENV NISE_DOMAIN cf-mini.example
 ENV NISE_PASSWORD c1oudc0w
 
 ADD run.sh /root/

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ Tested on Ubuntu 15.04 Docker Server w/ following:
 
 # dns:
 
-  The Dev space where your IDE/Browser/CLI are run that interface with CF must have a working internal DNS server setup for wildcard lookups against the fake "cf.mini" domain. Without this, you can't interact with CF outside of the Docker container.  The following is how I accomplished this on Ubuntu 15.04 (it will work on 12 & 14 also).  Similar solutions exist for other OS types. I've included a working Mac solution as well.
+  The Dev space where your IDE/Browser/CLI are run that interface with CF must have a working internal DNS server setup for wildcard lookups against the fake "cf-mini.example" domain. Without this, you can't interact with CF outside of the Docker container.  The following is how I accomplished this on Ubuntu 15.04 (it will work on 12 & 14 also).  Similar solutions exist for other OS types. I've included a working Mac solution as well.
 
 Ubuntu DNS server setup:
 
     $ apt-get update && apt-get install dnsmasq
 
     ## Docker Server IP in place of 10.x.x.x
-    $ echo -e '\naddress=/cf.mini/10.x.x.x' >> /etc/dnsmasq.conf
+    $ echo -e '\naddress=/cf-mini.example/10.x.x.x' >> /etc/dnsmasq.conf
     $ dpkg-reconfigure resolvconf # (YES to dynamic)
     $ /etc/init.d/dnsmasq restart
-    $ ping api.cf.mini
-    PING api.cf.mini (10.x.x.x) 56(84) bytes of data.
+    $ ping api.cf-mini.example
+    PING api.cf.example (10.x.x.x) 56(84) bytes of data.
     64 bytes from 10.x.x.x: icmp_seq=1 ttl=64 time=0.080 ms
 
 Macintosh DNS server setup:
@@ -61,24 +61,24 @@ Macintosh DNS server setup:
     $ cp $(brew list dnsmasq | grep /dnsmasq.conf.example$) /usr/local/etc/dnsmasq.conf
 
     ## Docker Server IP in place of 10.x.x.x
-    $ echo -e '\naddress=/cf.mini/10.x.x.x' >> /usr/local/etc/dnsmasq.conf
+    $ echo -e '\naddress=/cf-mini.example/10.x.x.x' >> /usr/local/etc/dnsmasq.conf
     $ sudo cp -fv /usr/local/opt/dnsmasq/*.plist /Library/LaunchDaemons/
     $ sudo chown root /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
     $ sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
     $ sudo mkdir -v /etc/resolver
-    $ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/cf.mini'
-    # DNS subdomain of cf.mini should be pointing to 127.0.0.1 for resolution
+    $ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/cf-mini.example'
+    # DNS subdomain of cf-mini.example should be pointing to 127.0.0.1 for resolution
     $ scutil --dns
     resolver #2
-      domain   : cf.mini
+      domain   : cf-mini.example
       nameserver[0] : 127.0.0.1
       flags    : Request A records, Request AAAA records
       reach    : Reachable,Local Address
 
     $ sudo launchctl stop homebrew.mxcl.dnsmasq
     $ sudo launchctl start homebrew.mxcl.dnsmasq
-    $ ping api.cf.mini
-    PING api.cf.mini (10.x.x.x): 56 data bytes
+    $ ping api.cf-mini.example
+    PING api.cf-mini.example (10.x.x.x): 56 data bytes
     64 bytes from 10.x.x.x: icmp_seq=0 ttl=64 time=6.240 ms
 
 # connect:
@@ -87,13 +87,13 @@ Cloud Foundry should take anywhere from 4 to 10 minutes to initialize the first 
 
   You'll know the stack is ready for use when you're able to access this ruby app:
 
-  <http://hello.cf.mini/>
+  <http://hello.cf-mini.example/>
 
-    $ curl http://hello.cf.mini
+    $ curl http://hello.cf-mini.example
     Hello, World!
 
 To connect via cli:
 
-    $ cf login -a https://api.cf.mini -u admin -p c1oudc0w --skip-ssl-validation
+    $ cf login -a https://api.cf-mini.example -u admin -p c1oudc0w --skip-ssl-validation
 
 CLI version 6.11.2 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.11.2>


### PR DESCRIPTION
Since the TLD .mini has been delegated to BMW I changed the TLD to use .example  
