### PR TITLE
v215 upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ADD spring-music /root/cf_nise_installer/test_apps/spring-music/
 ADD test_app /root/cf_nise_installer/test_apps/test_app/
 ADD supervisord.conf /etc/supervisor/conf.d/
 ADD run.sh /root/
+ADD monit_daemon.sh /root/
 ADD run_first.sh /root/
 RUN chmod u+x /root/*.sh & sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh & wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && f
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443
-CMD /root/run_first.sh ; /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf & /root/run.sh
+CMD /root/run_first.sh ; /root/run.sh & /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ADD test_app /root/cf_nise_installer/test_apps/test_app/
 ADD supervisord.conf /etc/supervisor/conf.d/
 ADD run.sh /root/
 ADD run_first.sh /root/
-RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.11.2&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
+RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 
 WORKDIR /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/
 RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' && find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD run_first.sh /root/
 RUN chmod u+x /root/*.sh & sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh & wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 
 WORKDIR /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/
-RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' & find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' & find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean
+RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' && find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && f
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443
-CMD /root/run_first.sh ; /root/run.sh & /usr/bin/supervisord
+CMD /root/run_first.sh ; /root/run.sh & /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ADD spring-music /root/cf_nise_installer/test_apps/spring-music/
 ADD test_app /root/cf_nise_installer/test_apps/test_app/
 ADD supervisord.conf /etc/supervisor/conf.d/
 ADD run.sh /root/
+ADD monit_daemon.sh /root/
 ADD run_first.sh /root/
 RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && f
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443
-CMD /root/run_first.sh ; /var/vcap/bosh/bin/monit -d 10 -I & /root/run.sh
+CMD /root/run_first.sh ; /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf & /root/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ ADD spring-music /root/cf_nise_installer/test_apps/spring-music/
 ADD test_app /root/cf_nise_installer/test_apps/test_app/
 ADD supervisord.conf /etc/supervisor/conf.d/
 ADD run.sh /root/
-ADD monit_daemon.sh /root/
 ADD run_first.sh /root/
 RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD run_first.sh /root/
 RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.11.2&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 
 WORKDIR /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/
-RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' && find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.4/bin/bundle install && /var/vcap/packages/ruby-2.1.4/bin/bundle clean
+RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' && find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Cloud Foundry running stack
-# version 0.1
-FROM tchughesiv/cf-mini-release:v205
+# version 0.2
+FROM tchughesiv/cf-mini-release:v215
 MAINTAINER Tommy Hughes <tchughesiv@gmail.com>
 
 WORKDIR /root
@@ -10,7 +10,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ENV HOME /root
-ENV INSTALLER_BRANCH v205
+ENV INSTALLER_BRANCH v215
 ENV NISE_DOMAIN cf-mini.example
 ENV NISE_PASSWORD c1oudc0w
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LC_ALL en_US.UTF-8
 
 ENV HOME /root
 ENV INSTALLER_BRANCH v215
-ENV NISE_DOMAIN cf.internal
+ENV NISE_DOMAIN cf-mini.example
 ENV NISE_PASSWORD c1oudc0w
 
 RUN mkdir /root/cf_nise_installer/test_apps && mkdir /root/cf_nise_installer/test_apps/spring-music && mkdir /root/cf_nise_installer/test_apps/cf-env && mkdir /root/cf_nise_installer/test_apps/test_app && rm -rf /root/cf_nise_installer/test_app && rm -f /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && f
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443
-CMD /root/run_first.sh ; /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf & /root/run.sh
+CMD /root/run_first.sh ; /var/vcap/bosh/bin/monit -d 10 -I & /root/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,18 @@ ENV INSTALLER_BRANCH v215
 ENV NISE_DOMAIN cf-mini.example
 ENV NISE_PASSWORD c1oudc0w
 
-RUN mkdir /root/cf_nise_installer/test_apps && mkdir /root/cf_nise_installer/test_apps/spring-music && mkdir /root/cf_nise_installer/test_apps/cf-env && mkdir /root/cf_nise_installer/test_apps/test_app && rm -rf /root/cf_nise_installer/test_app && rm -f /etc/supervisor/conf.d/supervisord.conf
+RUN mkdir /root/cf_nise_installer/test_apps && mkdir /root/cf_nise_installer/test_apps/spring-music & mkdir /root/cf_nise_installer/test_apps/cf-env & mkdir /root/cf_nise_installer/test_apps/test_app & rm -rf /root/cf_nise_installer/test_app & rm -f /etc/supervisor/conf.d/supervisord.conf
 ADD cf-env /root/cf_nise_installer/test_apps/cf-env/
 ADD spring-music /root/cf_nise_installer/test_apps/spring-music/
 ADD test_app /root/cf_nise_installer/test_apps/test_app/
 ADD supervisord.conf /etc/supervisor/conf.d/
 ADD run.sh /root/
 ADD run_first.sh /root/
-RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
+RUN chmod u+x /root/*.sh & sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh & wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 
 WORKDIR /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/
-RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' && find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean
+RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' & find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' & find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean
 
 WORKDIR /root/cf_nise_installer/test_apps
 EXPOSE 80 443 4443
-CMD /root/run_first.sh ; /root/run.sh & /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+CMD /root/run_first.sh ; /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf & /root/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LC_ALL en_US.UTF-8
 
 ENV HOME /root
 ENV INSTALLER_BRANCH v215
-ENV NISE_DOMAIN cf-mini.example
+ENV NISE_DOMAIN cf.internal
 ENV NISE_PASSWORD c1oudc0w
 
 RUN mkdir /root/cf_nise_installer/test_apps && mkdir /root/cf_nise_installer/test_apps/spring-music && mkdir /root/cf_nise_installer/test_apps/cf-env && mkdir /root/cf_nise_installer/test_apps/test_app && rm -rf /root/cf_nise_installer/test_app && rm -f /etc/supervisor/conf.d/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV INSTALLER_BRANCH v215
 ENV NISE_DOMAIN cf-mini.example
 ENV NISE_PASSWORD c1oudc0w
 
-RUN mkdir /root/cf_nise_installer/test_apps && mkdir /root/cf_nise_installer/test_apps/spring-music & mkdir /root/cf_nise_installer/test_apps/cf-env & mkdir /root/cf_nise_installer/test_apps/test_app & rm -rf /root/cf_nise_installer/test_app & rm -f /etc/supervisor/conf.d/supervisord.conf
+RUN mkdir /root/cf_nise_installer/test_apps && mkdir /root/cf_nise_installer/test_apps/spring-music && mkdir /root/cf_nise_installer/test_apps/cf-env && mkdir /root/cf_nise_installer/test_apps/test_app && rm -rf /root/cf_nise_installer/test_app && rm -f /etc/supervisor/conf.d/supervisord.conf
 ADD cf-env /root/cf_nise_installer/test_apps/cf-env/
 ADD spring-music /root/cf_nise_installer/test_apps/spring-music/
 ADD test_app /root/cf_nise_installer/test_apps/test_app/
@@ -22,7 +22,7 @@ ADD supervisord.conf /etc/supervisor/conf.d/
 ADD run.sh /root/
 ADD monit_daemon.sh /root/
 ADD run_first.sh /root/
-RUN chmod u+x /root/*.sh & sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh & wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
+RUN chmod u+x /root/*.sh && sed -i '/bundle install/d' /root/cf_nise_installer/scripts/install_cf_release.sh && wget -O /root/cf-cli_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.12.3&source=github-rel cf-cli_amd64.deb" && dpkg -i /root/cf-cli_amd64.deb && rm /root/cf-cli_amd64.deb
 
 WORKDIR /var/vcap/packages/cloud_controller_ng/cloud_controller_ng/
 RUN find . -type f -name "Gemfile*" | xargs sed -i '/pg/ s/0.16.0/0.17.1/g' && find . -type f -name "Gemfile*" | xargs sed -i '/eventmachine/ s/1.0.3/1.0.4/g' && find . -type f -name "Gemfile*" | xargs sed -i '/delayed_job/ s/4.0.4/4.0.6/g' && /var/vcap/packages/ruby-2.1.6/bin/bundle install && /var/vcap/packages/ruby-2.1.6/bin/bundle clean

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Cloud Foundry aims to simplify code deployments... once you have a working PaaS 
 CF Mini makes it a 2-step process... Pull & Run with Docker.
 
 # requirements:
-# requirements:
 
 A Docker server using "devicemapper w/ udev sync enabled" & at least 30gb disk is highly recommended. I intend to do further testing with the btrfs & overlay storage options soon. One's working Docker Server environment must have the following two critical things configured or performance will suffer.
   
@@ -29,7 +28,7 @@ A Docker server using "devicemapper w/ udev sync enabled" & at least 30gb disk i
      Udev Sync Supported: true
 
   Your container might be able to start with the devicemapper defaults, but won't last long.
-  
+
 # pull:
 
     $ docker pull tchughesiv/cf-mini

--- a/README.md
+++ b/README.md
@@ -11,23 +11,25 @@ Cloud Foundry aims to simplify code deployments... once you have a working PaaS 
 CF Mini makes it a 2-step process... Pull & Run with Docker.
 
 # requirements:
+# requirements:
 
-A Docker server using "overlay" storage & at least 30gb disk is highly recommended. I intend to do further testing with the btrfs storage options soon. One's working Docker Server environment must have the following two critical things configured or performance will suffer.
+A Docker server using "devicemapper w/ udev sync enabled" & at least 30gb disk is highly recommended. I intend to do further testing with the btrfs & overlay storage options soon. One's working Docker Server environment must have the following two critical things configured or performance will suffer.
   
   *[Installation instructions for my tested Ubuntu 15.04 server build are here](https://github.com/tchughesiv/cf-mini/blob/master/ubuntu15_04.md).*
 
   1.) Server process should look like this:
 
     $ ps -ef |grep -i docker
-    /usr/bin/docker daemon -H fd:// -s overlay
+    docker daemon -H fd:// -s devicemapper --storage-opt dm.basesize=30G
 
-  2.) Docker info should return this critical component:
+  2.) Docker info should return these critical components:
 
     $ docker info
-    Storage Driver: overlay
+    Storage Driver: devicemapper
+     Udev Sync Supported: true
 
-  Your container might be able to start with the defaults, but won't last long.
-
+  Your container might be able to start with the devicemapper defaults, but won't last long.
+  
 # pull:
 
     $ docker pull tchughesiv/cf-mini

--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ To connect via cli:
     $ cf login -a https://api.cf-mini.example -u admin -p c1oudc0w --skip-ssl-validation
 
 CLI version 6.11.2 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.11.2>
+
+![gif not loading](https://raw.githubusercontent.com/tchughesiv/CosgKBs/master/cfmini.gif "CF-Mini Demo")

--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ To connect via cli:
 
     $ cf login -a https://api.cf-mini.example -u admin -p c1oudc0w --skip-ssl-validation
 
-CLI version 6.11.2 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.11.2>
+CLI version 6.12.3 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.12.3>
 
 ![gif not loading](https://raw.githubusercontent.com/tchughesiv/images/master/cfmini.gif "CF-Mini Demo")

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ To connect via cli:
 
 CLI version 6.11.2 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.11.2>
 
-![gif not loading](https://raw.githubusercontent.com/tchughesiv/CosgKBs/master/cfmini.gif "CF-Mini Demo")
+![gif not loading](https://raw.githubusercontent.com/tchughesiv/images/master/cfmini.gif "CF-Mini Demo")

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ A Docker server using "devicemapper w/ udev sync enabled" & at least 30gb disk i
 
 # dns:
 
-  The Dev space where your IDE/Browser/CLI are run that interface with CF must have a working internal DNS server setup for wildcard lookups against the fake "cf.internal" domain. Without this, you can't interact with CF outside of the Docker container.  The following is how I accomplished this on Ubuntu 15.04 (it will work on 12 & 14 also).  Similar solutions exist for other OS types. I've included a working Mac solution as well.
+  The Dev space where your IDE/Browser/CLI are run that interface with CF must have a working internal DNS server setup for wildcard lookups against the fake "cf-mini.example" domain. Without this, you can't interact with CF outside of the Docker container.  The following is how I accomplished this on Ubuntu 15.04 (it will work on 12 & 14 also).  Similar solutions exist for other OS types. I've included a working Mac solution as well.
 
 Ubuntu DNS server setup:
 
     $ apt-get update && apt-get install dnsmasq
 
     ## Docker Server IP in place of 10.x.x.x
-    $ echo -e '\naddress=/cf.internal/10.x.x.x' >> /etc/dnsmasq.conf
+    $ echo -e '\naddress=/cf-mini.example/10.x.x.x' >> /etc/dnsmasq.conf
     $ dpkg-reconfigure resolvconf # (YES to dynamic)
     $ /etc/init.d/dnsmasq restart
-    $ ping api.cf.internal
-    PING api.cf.internal (10.x.x.x) 56(84) bytes of data.
+    $ ping api.cf-mini.example
+    PING api.cf-mini.example (10.x.x.x) 56(84) bytes of data.
     64 bytes from 10.x.x.x: icmp_seq=1 ttl=64 time=0.080 ms
 
 Macintosh DNS server setup:
@@ -59,24 +59,24 @@ Macintosh DNS server setup:
     $ cp $(brew list dnsmasq | grep /dnsmasq.conf.example$) /usr/local/etc/dnsmasq.conf
 
     ## Docker Server IP in place of 10.x.x.x
-    $ echo -e '\naddress=/cf.internal/10.x.x.x' >> /usr/local/etc/dnsmasq.conf
+    $ echo -e '\naddress=/cf-mini.example/10.x.x.x' >> /usr/local/etc/dnsmasq.conf
     $ sudo cp -fv /usr/local/opt/dnsmasq/*.plist /Library/LaunchDaemons/
     $ sudo chown root /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
     $ sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
     $ sudo mkdir -v /etc/resolver
-    $ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/cf.internal'
-    # DNS subdomain of cf.internal should be pointing to 127.0.0.1 for resolution
+    $ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/cf-mini.example'
+    # DNS subdomain of cf-mini.example should be pointing to 127.0.0.1 for resolution
     $ scutil --dns
     resolver #2
-      domain   : cf.internal
+      domain   : cf-mini.example
       nameserver[0] : 127.0.0.1
       flags    : Request A records, Request AAAA records
       reach    : Reachable,Local Address
 
     $ sudo launchctl stop homebrew.mxcl.dnsmasq
     $ sudo launchctl start homebrew.mxcl.dnsmasq
-    $ ping api.cf.internal
-    PING api.cf.internal (10.x.x.x): 56 data bytes
+    $ ping api.cf-mini.example
+    PING api.cf-mini.example (10.x.x.x): 56 data bytes
     64 bytes from 10.x.x.x: icmp_seq=0 ttl=64 time=6.240 ms
 
 # connect:
@@ -85,14 +85,14 @@ Cloud Foundry should take anywhere from 4 to 10 minutes to initialize the first 
 
   You'll know the stack is ready for use when you're able to access this ruby app:
 
-  <http://hello.cf.internal/>
+  <http://hello.cf-mini.example/>
 
-    $ curl hello.cf.internal
+    $ curl hello.cf-mini.example
     Hello, World!
 
 To connect via cli:
 
-    $ cf login -a https://api.cf.internal -u admin -p c1oudc0w --skip-ssl-validation
+    $ cf login -a https://api.cf-mini.example -u admin -p c1oudc0w --skip-ssl-validation
 
 CLI version 6.12.3 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.12.3>
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ A Docker server using "devicemapper w/ udev sync enabled" & at least 30gb disk i
 
 # dns:
 
-  The Dev space where your IDE/Browser/CLI are run that interface with CF must have a working internal DNS server setup for wildcard lookups against the fake "cf-mini.example" domain. Without this, you can't interact with CF outside of the Docker container.  The following is how I accomplished this on Ubuntu 15.04 (it will work on 12 & 14 also).  Similar solutions exist for other OS types. I've included a working Mac solution as well.
+  The Dev space where your IDE/Browser/CLI are run that interface with CF must have a working internal DNS server setup for wildcard lookups against the fake "cf.internal" domain. Without this, you can't interact with CF outside of the Docker container.  The following is how I accomplished this on Ubuntu 15.04 (it will work on 12 & 14 also).  Similar solutions exist for other OS types. I've included a working Mac solution as well.
 
 Ubuntu DNS server setup:
 
     $ apt-get update && apt-get install dnsmasq
 
     ## Docker Server IP in place of 10.x.x.x
-    $ echo -e '\naddress=/cf-mini.example/10.x.x.x' >> /etc/dnsmasq.conf
+    $ echo -e '\naddress=/cf.internal/10.x.x.x' >> /etc/dnsmasq.conf
     $ dpkg-reconfigure resolvconf # (YES to dynamic)
     $ /etc/init.d/dnsmasq restart
-    $ ping api.cf-mini.example
-    PING api.cf-mini.example (10.x.x.x) 56(84) bytes of data.
+    $ ping api.cf.internal
+    PING api.cf.internal (10.x.x.x) 56(84) bytes of data.
     64 bytes from 10.x.x.x: icmp_seq=1 ttl=64 time=0.080 ms
 
 Macintosh DNS server setup:
@@ -59,24 +59,24 @@ Macintosh DNS server setup:
     $ cp $(brew list dnsmasq | grep /dnsmasq.conf.example$) /usr/local/etc/dnsmasq.conf
 
     ## Docker Server IP in place of 10.x.x.x
-    $ echo -e '\naddress=/cf-mini.example/10.x.x.x' >> /usr/local/etc/dnsmasq.conf
+    $ echo -e '\naddress=/cf.internal/10.x.x.x' >> /usr/local/etc/dnsmasq.conf
     $ sudo cp -fv /usr/local/opt/dnsmasq/*.plist /Library/LaunchDaemons/
     $ sudo chown root /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
     $ sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
     $ sudo mkdir -v /etc/resolver
-    $ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/cf-mini.example'
-    # DNS subdomain of cf-mini.example should be pointing to 127.0.0.1 for resolution
+    $ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/cf.internal'
+    # DNS subdomain of cf.internal should be pointing to 127.0.0.1 for resolution
     $ scutil --dns
     resolver #2
-      domain   : cf-mini.example
+      domain   : cf.internal
       nameserver[0] : 127.0.0.1
       flags    : Request A records, Request AAAA records
       reach    : Reachable,Local Address
 
     $ sudo launchctl stop homebrew.mxcl.dnsmasq
     $ sudo launchctl start homebrew.mxcl.dnsmasq
-    $ ping api.cf-mini.example
-    PING api.cf-mini.example (10.x.x.x): 56 data bytes
+    $ ping api.cf.internal
+    PING api.cf.internal (10.x.x.x): 56 data bytes
     64 bytes from 10.x.x.x: icmp_seq=0 ttl=64 time=6.240 ms
 
 # connect:
@@ -85,14 +85,14 @@ Cloud Foundry should take anywhere from 4 to 10 minutes to initialize the first 
 
   You'll know the stack is ready for use when you're able to access this ruby app:
 
-  <http://hello.cf-mini.example/>
+  <http://hello.cf.internal/>
 
-    $ curl http://hello.cf-mini.example
+    $ curl hello.cf.internal
     Hello, World!
 
 To connect via cli:
 
-    $ cf login -a https://api.cf-mini.example -u admin -p c1oudc0w --skip-ssl-validation
+    $ cf login -a https://api.cf.internal -u admin -p c1oudc0w --skip-ssl-validation
 
 CLI version 6.12.3 works well with the stack:	<https://github.com/cloudfoundry/cli/releases/tag/v6.12.3>
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Docker image running Cloud Foundry stack - listens on ports 80/443/4443
 
 [![](https://badge.imagelayers.io/tchughesiv/cf-mini.svg)](https://imagelayers.io/?images=tchughesiv/cf-mini:latest 'Get your own badge on imagelayers.io')
 
-    Ubuntu Precise 12.04.05
-    Cloud Foundry v205
+    Ubuntu Trusty 14.04
+    Cloud Foundry v215
 
 Cloud Foundry aims to simplify code deployments... once you have a working PaaS stack anyway. Accomplishing this initial setup/install task of the stack itself, however, can be cumbersome.
 
@@ -12,22 +12,21 @@ CF Mini makes it a 2-step process... Pull & Run with Docker.
 
 # requirements:
 
-A Docker server using "devicemapper w/ udev sync enabled" & at least 30gb disk is highly recommended. I intend to do further testing with the btrfs & overlay storage options soon. One's working Docker Server environment must have the following two critical things configured or performance will suffer.
+A Docker server using "overlay" storage & at least 30gb disk is highly recommended. I intend to do further testing with the btrfs storage options soon. One's working Docker Server environment must have the following two critical things configured or performance will suffer.
   
   *[Installation instructions for my tested Ubuntu 15.04 server build are here](https://github.com/tchughesiv/cf-mini/blob/master/ubuntu15_04.md).*
 
   1.) Server process should look like this:
 
     $ ps -ef |grep -i docker
-    docker -d -s devicemapper --storage-opt dm.basesize=30G
+    /usr/bin/docker daemon -H fd:// -s overlay
 
-  2.) Docker info should return these critical components:
+  2.) Docker info should return this critical component:
 
     $ docker info
-    Storage Driver: devicemapper
-     Udev Sync Supported: true
+    Storage Driver: overlay
 
-  Your container might be able to start with the devicemapper defaults, but won't last long.
+  Your container might be able to start with the defaults, but won't last long.
 
 # pull:
 

--- a/monit_daemon.sh
+++ b/monit_daemon.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+set -eu
+
+pidfile="/var/run/monit.pid"
+command=/var/vcap/bosh/bin/monit
+
+# Proxy signals
+function kill_app(){
+    kill $(cat $pidfile)
+    exit 0 # exit okay
+}
+trap "kill_app" SIGINT SIGTERM
+
+# Launch daemon
+$command
+sleep 2
+
+# Loop while the pidfile and the process exist
+while [ -f $pidfile ] && kill -0 $(cat $pidfile) ; do
+    sleep 0.5
+done
+exit 1000 # exit unexpected

--- a/monit_daemon.sh
+++ b/monit_daemon.sh
@@ -19,4 +19,5 @@ sleep 2
 while [ -f $pidfile ] && kill -0 $(cat $pidfile) ; do
     sleep 0.5
 done
+
 exit 1000 # exit unexpected

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ echo
 echo "Waiting for postgres to start..."
 echo
 for ((i=0; i < 120; i++)); do
-    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "running$"); then
+    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
     sleep 10
@@ -26,7 +26,7 @@ echo
 echo "Waiting for nats to start..."
 echo
 for ((i=0; i < 120; i++)); do
-    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "running$"); then
+    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
     sleep 10
@@ -42,7 +42,7 @@ echo
 echo "Waiting for remaining processes to start..."
 echo
 for ((i=0; i < 120; i++)); do
-    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "running$"); then
+    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
         cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation
         cf create-space dev
         cf t -s dev

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
+/var/vcap/bosh/bin/monit
 
-sleep 5
+sleep 3
 echo "Starting postres job..."
 /var/vcap/bosh/bin/monit start postgres
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-/var/vcap/bosh/bin/monit
 
 sleep 3
 echo "Starting postres job..."

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,6 @@
 #! /bin/bash
 
-/var/vcap/bosh/bin/monit
-
-sleep 3
+sleep 5
 echo "Starting postres job..."
 /var/vcap/bosh/bin/monit start postgres
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+/var/vcap/bosh/bin/monit
+
 sleep 3
 echo "Starting postres job..."
 /var/vcap/bosh/bin/monit start postgres

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,6 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 3
     echo
     echo "Waiting for postgres to start..."
     echo
@@ -20,7 +19,7 @@ done
 # su - vcap -c "/var/vcap/data/packages/postgres/*/bin/pg_ctl reload -D /var/vcap/store/postgres"
 
 echo "Starting nats job..."
-/var/vcap/bosh/bin/monit start nats gorouter cloud_controller_ng
+/var/vcap/bosh/bin/monit start nats
 
 echo
 echo "Waiting for nats to start..."
@@ -29,7 +28,6 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 3
     echo
     echo "Waiting for nats to start..."
     echo
@@ -44,14 +42,13 @@ echo
 for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
         cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation
+        cf create-space dev
         cf t -s dev
         cd /root/cf_nise_installer/test_apps/test_app/
-        cf app hello
+        cf push
         echo
-        echo "cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation"
         break
     fi
-    sleep 3
     echo
     echo "Waiting for remaining processes to start..."
     echo

--- a/run.sh
+++ b/run.sh
@@ -41,12 +41,13 @@ echo "Waiting for remaining processes to start..."
 echo
 for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
-        cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation
+        cf login -a https://api.$NISE_DOMAIN -o DevBox -u admin -p $NISE_PASSWORD --skip-ssl-validation
         cf create-space dev
         cf t -s dev
         cd /root/cf_nise_installer/test_apps/test_app/
         cf push
         echo
+        echo "cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation"
         break
     fi
     echo

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ done
 # su - vcap -c "/var/vcap/data/packages/postgres/*/bin/pg_ctl reload -D /var/vcap/store/postgres"
 
 echo "Starting nats job..."
-/var/vcap/bosh/bin/monit start nats
+/var/vcap/bosh/bin/monit start nats gorouter cloud_controller_ng
 
 echo
 echo "Waiting for nats to start..."

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-sleep 15
+sleep 5
 echo "Starting postres job..."
 /var/vcap/bosh/bin/monit start postgres
 
@@ -11,7 +11,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 10
+    sleep 3
     echo
     echo "Waiting for postgres to start..."
     echo
@@ -29,7 +29,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 10
+    sleep 3
     echo
     echo "Waiting for nats to start..."
     echo
@@ -51,7 +51,7 @@ for ((i=0; i < 120; i++)); do
         echo "cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation"
         break
     fi
-    sleep 10
+    sleep 3
     echo
     echo "Waiting for remaining processes to start..."
     echo

--- a/run.sh
+++ b/run.sh
@@ -44,10 +44,9 @@ echo
 for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
         cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation
-        cf create-space dev
         cf t -s dev
         cd /root/cf_nise_installer/test_apps/test_app/
-        cf push
+        cf app hello
         echo
         echo "cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation"
         break

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
+    sleep 5
     echo
     echo "Waiting for postgres to start..."
     echo
@@ -28,6 +29,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
+    sleep 5
     echo
     echo "Waiting for nats to start..."
     echo
@@ -50,6 +52,7 @@ for ((i=0; i < 120; i++)); do
         echo "cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation"
         break
     fi
+    sleep 5
     echo
     echo "Waiting for remaining processes to start..."
     echo

--- a/run_first.sh
+++ b/run_first.sh
@@ -28,7 +28,9 @@ cd /root/cf_nise_installer/
 rsyslogd
 NISE_IP_ADDRESS=${NISE_IP_ADDRESS:-`ip addr | grep 'inet .*global' | cut -f 6 -d ' ' | cut -f1 -d '/' | head -n 1`}
 sed -i "/${NISE_DOMAIN}/d" /etc/dnsmasq.conf
+sed -i "/cf.internal/d" /etc/dnsmasq.conf
 echo "address=/$NISE_DOMAIN/$NISE_IP_ADDRESS" >> /etc/dnsmasq.conf
+echo "address=/cf.internal/$NISE_IP_ADDRESS" >> /etc/dnsmasq.conf
 
 cp -p /etc/resolv.conf /etc/resolv.old
 grep -i nameserver /etc/resolv.old > /etc/resolv.dnsmasq.conf

--- a/run_first.sh
+++ b/run_first.sh
@@ -72,7 +72,7 @@ sed -i '/kernel.shmmax/d' /var/vcap/jobs/postgres/bin/postgres_ctl
 /var/vcap/bosh/bin/monit quit
 /var/vcap/bosh/bin/monit
 
-sleep 10
+sleep 5
 echo "Starting postres job..."
 /var/vcap/bosh/bin/monit start postgres
 
@@ -83,6 +83,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
+    sleep 5
     echo
     echo "Waiting for postgres to start..."
     echo
@@ -98,6 +99,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
+    sleep 5
     echo
     echo "Waiting for nats to start..."
     echo
@@ -113,6 +115,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
         break
     fi
+    sleep 5
     echo
     echo "Waiting for remaining processes to start..."
     echo

--- a/run_first.sh
+++ b/run_first.sh
@@ -123,6 +123,7 @@ for ((i=0; i < 120; i++)); do
     echo
 done
 
+sleep 30
 /var/vcap/bosh/bin/monit quit
 /var/vcap/bosh/bin/monit stop all
 /var/vcap/bosh/bin/monit stop all

--- a/run_first.sh
+++ b/run_first.sh
@@ -83,13 +83,10 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 3
     echo
     echo "Waiting for postgres to start..."
     echo
 done
-
-# su - vcap -c "/var/vcap/data/packages/postgres/*/bin/pg_ctl reload -D /var/vcap/store/postgres"
 
 echo "Starting nats job..."
 /var/vcap/bosh/bin/monit start nats
@@ -101,7 +98,6 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 3
     echo
     echo "Waiting for nats to start..."
     echo
@@ -115,15 +111,8 @@ echo "Waiting for remaining processes to start..."
 echo
 for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
-        cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation
-        cf create-space dev
-        cf t -s dev
-        cd /root/cf_nise_installer/test_apps/test_app/
-        cf push
-        echo
         break
     fi
-    sleep 3
     echo
     echo "Waiting for remaining processes to start..."
     echo

--- a/run_first.sh
+++ b/run_first.sh
@@ -115,6 +115,12 @@ echo "Waiting for remaining processes to start..."
 echo
 for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
+        cf login -a https://api.$NISE_DOMAIN -u admin -p $NISE_PASSWORD --skip-ssl-validation
+        cf create-space dev
+        cf t -s dev
+        cd /root/cf_nise_installer/test_apps/test_app/
+        cf push
+        echo
         break
     fi
     sleep 10
@@ -123,7 +129,7 @@ for ((i=0; i < 120; i++)); do
     echo
 done
 
-sleep 30
+sleep 20
 /var/vcap/bosh/bin/monit quit
 /var/vcap/bosh/bin/monit stop all
 /var/vcap/bosh/bin/monit stop all

--- a/run_first.sh
+++ b/run_first.sh
@@ -83,7 +83,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 10
+    sleep 3
     echo
     echo "Waiting for postgres to start..."
     echo
@@ -101,7 +101,7 @@ for ((i=0; i < 120; i++)); do
     if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
-    sleep 10
+    sleep 3
     echo
     echo "Waiting for nats to start..."
     echo
@@ -123,13 +123,12 @@ for ((i=0; i < 120; i++)); do
         echo
         break
     fi
-    sleep 10
+    sleep 3
     echo
     echo "Waiting for remaining processes to start..."
     echo
 done
 
-sleep 20
 /var/vcap/bosh/bin/monit quit
 /var/vcap/bosh/bin/monit stop all
 /var/vcap/bosh/bin/monit stop all

--- a/run_first.sh
+++ b/run_first.sh
@@ -78,7 +78,7 @@ echo
 echo "Waiting for postgres to start..."
 echo
 for ((i=0; i < 120; i++)); do
-    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "running$"); then
+    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i postgres | grep -v -E "(running|accessible)$"); then
         break
     fi
     sleep 10
@@ -96,7 +96,7 @@ echo
 echo "Waiting for nats to start..."
 echo
 for ((i=0; i < 120; i++)); do
-    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "running$"); then
+    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -i nats | grep -v -E "(running|accessible)$"); then
         break
     fi
     sleep 10
@@ -112,7 +112,7 @@ echo
 echo "Waiting for remaining processes to start..."
 echo
 for ((i=0; i < 120; i++)); do
-    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "running$"); then
+    if ! (/var/vcap/bosh/bin/monit summary | tail -n +3 | grep -v -E "(running|accessible)$"); then
         break
     fi
     sleep 10

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command=/root/monit_daemon.sh
+command=/var/vcap/bosh/bin/monit -I

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command=sleep inf
+command=/root/monit_daemon.sh

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command=/var/vcap/bosh/bin/monit -I
+command=/var/vcap/bosh/bin/monit

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
 nodaemon=true
 
-[program:monit]
+[program:sleep]
 command=/bin/sleep inf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command=/var/vcap/bosh/bin/monit -I
+command=/root/monit_daemon.sh

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command=/var/vcap/bosh/bin/monit
+command="sleep inf"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command=/root/monit_daemon.sh
+command=sleep inf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:monit]
-command="sleep inf"
+command=/bin/sleep inf

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:sleep]
-command=/bin/sleep inf
+command=/root/monit_daemon.sh

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
 nodaemon=true
 
-[program:sleep]
+[program:monit]
 command=/root/monit_daemon.sh

--- a/ubuntu15_04.md
+++ b/ubuntu15_04.md
@@ -28,12 +28,6 @@ $ echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/do
 $ apt-key adv --keyserver pgp.mit.edu --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 $ apt-get update
 $ apt-get install -y docker-engine
-$ vi /etc/default/grub
-GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
-
-$ update-grub
-$ reboot now
-
 $ vi /lib/systemd/system/docker.service
 [Service]
 Type=notify
@@ -43,8 +37,12 @@ ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
 $ vi /etc/default/docker
 DOCKER_OPTS="-s devicemapper --storage-opt dm.basesize=30G"
 
-$ systemctl daemon-reload
-$ systemctl restart docker
+$ vi /etc/default/grub
+GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
+
+$ update-grub
+$ reboot now
+
 $ docker info
 Storage Driver: devicemapper
  Udev Sync Supported: true

--- a/ubuntu15_04.md
+++ b/ubuntu15_04.md
@@ -23,7 +23,7 @@ ii  libudev-dev:amd64                   219-7ubuntu5                 amd64      
 ii  libudev1:amd64                      219-7ubuntu5                 amd64        libudev shared library
 ii  udev                                219-7ubuntu5                 amd64        /dev/ and hotplug management daemon
 
-# TESTED WITH DOCKER 1.8.1 SO ITS WHAT I RECOMMEND FOR NOW
+# TESTED WITH DOCKER-ENGINE 1.8.1 SO ITS WHAT I RECOMMEND FOR NOW
 $ echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 $ apt-key adv --keyserver pgp.mit.edu --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 $ apt-get update

--- a/ubuntu15_04.md
+++ b/ubuntu15_04.md
@@ -14,7 +14,7 @@ $ do-release-upgrade (may have to do this more than once to get to 15.04)
 _IF starting with **Ubuntu 15.04 (Vivid Vervet)**, start here:_
 
 ```shell
-$ apt-get update && apt-get -y install libdevmapper* libudev* udev aufs-tools libdevmapper-event* libudev-dev libdevmapper-dev golang make gcc btrfs-tools libsqlite3-dev overlayroot debootstrap
+$ apt-get update && apt-get -y install libdevmapper* libudev* udev aufs-tools libdevmapper-event* libudev-dev libdevmapper-dev golang make gcc btrfs-tools libsqlite3-dev overlayroot debootstrap linux-image-generic curl
 $ dpkg -l | grep -E '(mapper|udev)'
 ii  libdevmapper-dev:amd64              2:1.02.90-2ubuntu1           amd64        Linux Kernel Device Mapper header files
 ii  libdevmapper-event1.02.1:amd64      2:1.02.90-2ubuntu1           amd64        Linux Kernel Device Mapper event support library
@@ -23,11 +23,9 @@ ii  libudev-dev:amd64                   219-7ubuntu5                 amd64      
 ii  libudev1:amd64                      219-7ubuntu5                 amd64        libudev shared library
 ii  udev                                219-7ubuntu5                 amd64        /dev/ and hotplug management daemon
 
-# TESTED WITH DOCKER-ENGINE 1.8.1 SO ITS WHAT I RECOMMEND FOR NOW
-$ echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-$ apt-key adv --keyserver pgp.mit.edu --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-$ apt-get update
-$ apt-get install -y docker-engine
+# TESTED WITH DOCKER-ENGINE (v1.8.1 or later) SO ITS WHAT I RECOMMEND FOR NOW
+$ curl -sSL https://get.docker.com/ | sh
+$ systemctl enable docker
 $ vi /lib/systemd/system/docker.service
 [Service]
 Type=notify
@@ -37,6 +35,7 @@ ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
 $ vi /etc/default/docker
 DOCKER_OPTS="-s devicemapper --storage-opt dm.basesize=30G"
 
+$ systemctl daemon-reload
 $ vi /etc/default/grub
 GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 

--- a/ubuntu15_04.md
+++ b/ubuntu15_04.md
@@ -14,6 +14,7 @@ $ do-release-upgrade (may have to do this more than once to get to 15.04)
 _IF starting with **Ubuntu 15.04 (Vivid Vervet)**, start here:_
 
 ```shell
+# install storage requirements for overlay & devicemapper w/ udev (just in case)
 $ apt-get update && apt-get -y install libdevmapper* libudev* udev aufs-tools libdevmapper-event* libudev-dev libdevmapper-dev golang make gcc btrfs-tools libsqlite3-dev overlayroot debootstrap
 $ dpkg -l | grep -E '(mapper|udev)'
 ii  libdevmapper-dev:amd64              2:1.02.90-2ubuntu1           amd64        Linux Kernel Device Mapper header files
@@ -23,29 +24,27 @@ ii  libudev-dev:amd64                   219-7ubuntu5                 amd64      
 ii  libudev1:amd64                      219-7ubuntu5                 amd64        libudev shared library
 ii  udev                                219-7ubuntu5                 amd64        /dev/ and hotplug management daemon
 
-# WORKS WITH DOCKER 1.6.2 SO ITS WHAT I RECOMMEND FOR NOW
-$ echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-$ apt-key adv --keyserver pgp.mit.edu --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-$ apt-get update
-$ apt-get install -y lxc-docker-1.6.2
 $ vi /etc/default/grub
 GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
 $ update-grub
 $ reboot now
 
-$ cd ~
-$ git clone --branch v1.6.2 https://github.com/docker/docker
-$ cd docker
-$ DOCKER_BUILDTAGS=btrfs_noversion AUTO_GOPATH=1 ./hack/make.sh dynbinary
+# install Docker & change storage type to Overlay
+$ curl -sSL https://get.docker.com/ | sh
+$ systemctl stop docker
+$ vi /lib/systemd/system/docker.service
+[Service]
+Type=notify
+EnvironmentFile=/etc/default/docker
+ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
 
-$ service docker stop
-$ cp -p bundles/1.6.2/dynbinary/dockerinit-1.6.2 /var/lib/docker/init;cp -p bundles/1.6.2/dynbinary/docker-1.6.2 /usr/bin/docker
+$ vi /etc/default/docker
+DOCKER_OPTS="-s overlay"
 
-# next docker version will fix auto startup (systemctl integration) and DOCKER_OPTS ability for 15.04... for now though, we'll run docker manually for this test.
-$ docker -d -s devicemapper --storage-opt dm.basesize=30G &
+$ systemctl daemon-reload
+$ systemctl start docker
 
 $ docker info
-Storage Driver: devicemapper
- Udev Sync Supported: true
+Storage Driver: overlay
 ```

--- a/ubuntu15_04.md
+++ b/ubuntu15_04.md
@@ -34,8 +34,6 @@ GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 $ update-grub
 $ reboot now
 
-$ systemctl stop docker
-$ cd ~
 $ vi /lib/systemd/system/docker.service
 [Service]
 Type=notify
@@ -46,7 +44,7 @@ $ vi /etc/default/docker
 DOCKER_OPTS="-s devicemapper --storage-opt dm.basesize=30G"
 
 $ systemctl daemon-reload
-$ systemctl start docker
+$ systemctl restart docker
 $ docker info
 Storage Driver: devicemapper
  Udev Sync Supported: true

--- a/ubuntu15_04.md
+++ b/ubuntu15_04.md
@@ -14,7 +14,6 @@ $ do-release-upgrade (may have to do this more than once to get to 15.04)
 _IF starting with **Ubuntu 15.04 (Vivid Vervet)**, start here:_
 
 ```shell
-# install storage requirements for overlay & devicemapper w/ udev (just in case)
 $ apt-get update && apt-get -y install libdevmapper* libudev* udev aufs-tools libdevmapper-event* libudev-dev libdevmapper-dev golang make gcc btrfs-tools libsqlite3-dev overlayroot debootstrap
 $ dpkg -l | grep -E '(mapper|udev)'
 ii  libdevmapper-dev:amd64              2:1.02.90-2ubuntu1           amd64        Linux Kernel Device Mapper header files
@@ -24,15 +23,19 @@ ii  libudev-dev:amd64                   219-7ubuntu5                 amd64      
 ii  libudev1:amd64                      219-7ubuntu5                 amd64        libudev shared library
 ii  udev                                219-7ubuntu5                 amd64        /dev/ and hotplug management daemon
 
+# TESTED WITH DOCKER 1.8.1 SO ITS WHAT I RECOMMEND FOR NOW
+$ echo deb http://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+$ apt-key adv --keyserver pgp.mit.edu --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+$ apt-get update
+$ apt-get install -y docker-engine
 $ vi /etc/default/grub
 GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
 $ update-grub
 $ reboot now
 
-# install Docker & change storage type to Overlay
-$ curl -sSL https://get.docker.com/ | sh
 $ systemctl stop docker
+$ cd ~
 $ vi /lib/systemd/system/docker.service
 [Service]
 Type=notify
@@ -40,11 +43,11 @@ EnvironmentFile=/etc/default/docker
 ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
 
 $ vi /etc/default/docker
-DOCKER_OPTS="-s overlay"
+DOCKER_OPTS="-s devicemapper --storage-opt dm.basesize=30G"
 
 $ systemctl daemon-reload
 $ systemctl start docker
-
 $ docker info
-Storage Driver: overlay
+Storage Driver: devicemapper
+ Udev Sync Supported: true
 ```


### PR DESCRIPTION
- upgrade OS to Ubuntu Trusty 14.04
- upgrade CF to v215
- dns added for cf.internal domain for internal services communication 
- cf cli upgrade to 6.12.3
- supervisord and monit settings modified
- docker engine install instructions modified
- new build packs included and old ones upgraded:
  java_buildpack
  staticfile_buildpack
  binary_buildpack
  ruby_buildpack
  nodejs_buildpack
